### PR TITLE
Added ability to run a custom command when the user clicks on panel widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ Go to genmon plugin properties and add next settings:
 | -n | --endpoint   | 707eff            | Endpoint color |
 | -h | --handshake  | a164e0            | Handshake color |
 | -t | --transfer   | f1e552            | Transfer color |
+| -c | --command    | poll vpn status   | Custom command to run on click |

--- a/wireguard-monitor
+++ b/wireguard-monitor
@@ -8,6 +8,7 @@ ipColor="9dffa8"
 endpointColor="707eff"
 handshakeColor="a164e0"
 transferColor="f1e552"
+refreshCommand="xfce4-panel --plugin-event=${widgetName}:refresh:bool:true"
 
 # --- vars
 scriptDir=$(dirname $(realpath ${0}))
@@ -57,6 +58,11 @@ do
         shift # past argument
         shift # past value
         ;;
+        -c|--command)
+        refreshCommand="$2"
+        shift # past argument
+        shift # past value
+        ;;
         *)    # unknown option
         # Get icon sizes list
         foundIconSizes=$(echo $(ls -1 ${scriptDir}/icons/wg-on-*.png | sed -n "s/.*\wg-on-\([0-9]*\)\.png/\1/p"))
@@ -70,6 +76,7 @@ do
         echo -e "    -n --endpoint ${endpointColor}\tEndpoint color"
         echo -e "    -h --handshake ${handshakeColor}\tHandshake color"
         echo -e "    -t --transfer ${transferColor}\tTransfer color"
+        echo -e "    -c --command \t\tCommand to execute on click"
         exit 0
         ;;
     esac
@@ -77,7 +84,6 @@ done
 
 
 # --- Icon click and text (for script start error case) click command - script restart
-refreshCommand="xfce4-panel --plugin-event=${widgetName}:refresh:bool:true"
 result="<click>${refreshCommand}</click>"
 result+="<txtclick>${refreshCommand}</txtclick>"
 

--- a/wireguard-monitor
+++ b/wireguard-monitor
@@ -8,7 +8,7 @@ ipColor="9dffa8"
 endpointColor="707eff"
 handshakeColor="a164e0"
 transferColor="f1e552"
-refreshCommand="xfce4-panel --plugin-event=${widgetName}:refresh:bool:true"
+refreshCommand=""
 
 # --- vars
 scriptDir=$(dirname $(realpath ${0}))
@@ -19,7 +19,7 @@ do
     key="$1"
     case $key in
         -n|--name)
-        widgetName="genmon-$2"
+        refreshCommand="xfce4-panel --plugin-event=genmon-$2:refresh:bool:true"
         shift # past argument
         shift # past value
         ;;


### PR DESCRIPTION
Added a -c (--command) command line argument to enable the user to run a custom command when a click event occurs on the panel widget. I used this to toggle the status of the vpn and refresh the widget on demand.
I can provide my vpn toggle code as an example if you're interested.

Thank you for your work!